### PR TITLE
Swift 3.0 support

### DIFF
--- a/HEXColor.xcodeproj/project.pbxproj
+++ b/HEXColor.xcodeproj/project.pbxproj
@@ -202,9 +202,11 @@
 					};
 					AA06B5051BC225210049FE14 = {
 						CreatedOnToolsVersion = 7.0.1;
+						LastSwiftMigration = 0800;
 					};
 					AA06B50F1BC225210049FE14 = {
 						CreatedOnToolsVersion = 7.0.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -435,6 +437,7 @@
 				PRODUCT_NAME = HEXColor;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -454,6 +457,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.pdq.HEXColor;
 				PRODUCT_NAME = HEXColor;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -464,6 +468,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pdq.HEXColorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -474,6 +479,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pdq.HEXColorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/HEXColor/UIColorExtension.swift
+++ b/HEXColor/UIColorExtension.swift
@@ -13,10 +13,10 @@ import UIKit
  UnableToScanHexValue:      "Scan hex error"
  MismatchedHexStringLength: "Invalid RGB string, number of characters after '#' should be either 3, 4, 6 or 8"
  */
-public enum UIColorInputError : ErrorType {
-    case MissingHashMarkAsPrefix,
-    UnableToScanHexValue,
-    MismatchedHexStringLength
+public enum UIColorInputError : ErrorProtocol {
+    case missingHashMarkAsPrefix,
+    unableToScanHexValue,
+    mismatchedHexStringLength
 }
 
 extension UIColor {
@@ -84,13 +84,13 @@ extension UIColor {
      */
     public convenience init(rgba_throws rgba: String) throws {
         guard rgba.hasPrefix("#") else {
-            throw UIColorInputError.MissingHashMarkAsPrefix
+            throw UIColorInputError.missingHashMarkAsPrefix
         }
         
-        guard let hexString: String = rgba.substringFromIndex(rgba.startIndex.advancedBy(1)),
+        guard let hexString: String = rgba.substring(from: rgba.characters.index(rgba.startIndex, offsetBy: 1)),
             var   hexValue:  UInt32 = 0
-            where NSScanner(string: hexString).scanHexInt(&hexValue) else {
-                throw UIColorInputError.UnableToScanHexValue
+            where Scanner(string: hexString).scanHexInt32(&hexValue) else {
+                throw UIColorInputError.unableToScanHexValue
         }
         
         switch (hexString.characters.count) {
@@ -103,7 +103,7 @@ extension UIColor {
         case 8:
             self.init(hex8: hexValue)
         default:
-            throw UIColorInputError.MismatchedHexStringLength
+            throw UIColorInputError.mismatchedHexStringLength
         }
     }
     
@@ -112,12 +112,12 @@ extension UIColor {
      
      - parameter rgba: String value.
      */
-    public convenience init(rgba: String, defaultColor: UIColor = UIColor.clearColor()) {
+    public convenience init(rgba: String, defaultColor: UIColor = UIColor.clear()) {
         guard let color = try? UIColor(rgba_throws: rgba) else {
-            self.init(CGColor: defaultColor.CGColor)
+            self.init(cgColor: defaultColor.cgColor)
             return
         }
-        self.init(CGColor: color.CGColor)
+        self.init(cgColor: color.cgColor)
     }
     
     /**
@@ -125,7 +125,7 @@ extension UIColor {
      
      - parameter rgba: Whether the alpha should be included.
      */
-    public func hexString(includeAlpha: Bool) -> String {
+    public func hexString(_ includeAlpha: Bool) -> String {
         var r: CGFloat = 0
         var g: CGFloat = 0
         var b: CGFloat = 0

--- a/HEXColorTests/HEXColorTests.swift
+++ b/HEXColorTests/HEXColorTests.swift
@@ -231,11 +231,11 @@ class HEXColorTests: XCTestCase {
     func testStringInputErrorMissingHashMarkAsPrefix() {
         do {
             let _ = try UIColor(rgba_throws: "FFFFFFFF")
-        } catch UIColorInputError.MissingHashMarkAsPrefix {
+        } catch UIColorInputError.missingHashMarkAsPrefix {
             XCTAssertTrue(true)
-        } catch UIColorInputError.UnableToScanHexValue {
+        } catch UIColorInputError.unableToScanHexValue {
             XCTAssertTrue(false)
-        } catch UIColorInputError.MismatchedHexStringLength {
+        } catch UIColorInputError.mismatchedHexStringLength {
             XCTAssertTrue(false)
         } catch {
             XCTAssertTrue(false)
@@ -245,11 +245,11 @@ class HEXColorTests: XCTestCase {
     func testStringInputErrorMismatchedHexStringLength() {
         do {
             let _ = try UIColor(rgba_throws: "#FFFFFFF")
-        } catch UIColorInputError.MissingHashMarkAsPrefix {
+        } catch UIColorInputError.missingHashMarkAsPrefix {
             XCTAssertTrue(false)
-        } catch UIColorInputError.UnableToScanHexValue {
+        } catch UIColorInputError.unableToScanHexValue {
             XCTAssertTrue(false)
-        } catch UIColorInputError.MismatchedHexStringLength {
+        } catch UIColorInputError.mismatchedHexStringLength {
             XCTAssertTrue(true)
         } catch {
             XCTAssertTrue(false)
@@ -259,11 +259,11 @@ class HEXColorTests: XCTestCase {
     func testStringInputErrorUnableToScanHexValue() {
         do {
             let _ = try UIColor(rgba_throws: "#ONMPQRST")
-        } catch UIColorInputError.MissingHashMarkAsPrefix {
+        } catch UIColorInputError.missingHashMarkAsPrefix {
             XCTAssertTrue(false)
-        } catch UIColorInputError.UnableToScanHexValue {
+        } catch UIColorInputError.unableToScanHexValue {
             XCTAssertTrue(true)
-        } catch UIColorInputError.MismatchedHexStringLength {
+        } catch UIColorInputError.mismatchedHexStringLength {
             XCTAssertTrue(false)
         } catch {
             XCTAssertTrue(false)
@@ -274,11 +274,11 @@ class HEXColorTests: XCTestCase {
     
     func testStringDefaultColor() {
         var color = UIColor(rgba: "FFFFFFFF")
-        XCTAssertEqual(color, UIColor.clearColor())
+        XCTAssertEqual(color, UIColor.clear())
         color = UIColor(rgba: "#FFFFFFF")
-        XCTAssertEqual(color, UIColor.clearColor())
+        XCTAssertEqual(color, UIColor.clear())
         color = UIColor(rgba: "#ONMPQRST")
-        XCTAssertEqual(color, UIColor.clearColor())
+        XCTAssertEqual(color, UIColor.clear())
     }
     
     // MARK: - Hex string output
@@ -288,7 +288,7 @@ class HEXColorTests: XCTestCase {
         XCTAssertEqual("#224466", color.hexString(false))
         XCTAssertEqual("#22446688", color.hexString(true))
         
-        let hexColor = UIColor(rgba: "#AABBCCDD", defaultColor: UIColor.yellowColor());
+        let hexColor = UIColor(rgba: "#AABBCCDD", defaultColor: UIColor.yellow());
         XCTAssertEqual("#AABBCC", hexColor.hexString(false))
         XCTAssertEqual("#AABBCCDD", hexColor.hexString(true))
     }
@@ -300,7 +300,7 @@ class HEXColorTests: XCTestCase {
         XCTAssertEqual("#22446688", color.description)
         XCTAssertEqual("#22446688", color.debugDescription)
         
-        let hexColor = UIColor(rgba: "#AABBCCDD", defaultColor: UIColor.yellowColor());
+        let hexColor = UIColor(rgba: "#AABBCCDD", defaultColor: UIColor.yellow());
         XCTAssertEqual("#AABBCCDD", hexColor.description)
         XCTAssertEqual("#AABBCCDD", hexColor.debugDescription)
     }
@@ -314,7 +314,7 @@ extension UIColor {
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
         self.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-        return (toUInt8(red), toUInt8(green), toUInt8(blue), toUInt8(alpha))
+        return (toUInt8(value: red), toUInt8(value: green), toUInt8(value: blue), toUInt8(value: alpha))
     }
 }
 


### PR DESCRIPTION
Migrated the project to Swift 3.0. Do not merge this one before Xcode 8 is finally released. To use it in the meanwhile use the following pod: 
`pod 'UIColor_Hex_Swift', :git=> 'git@github.com:e-Sixt/UIColor-Hex-Swift.git', :branch => 'master'`