### PR TITLE
Improve compile time

### DIFF
--- a/HEXColor/UIColorExtension.swift
+++ b/HEXColor/UIColorExtension.swift
@@ -168,17 +168,13 @@ extension String {
         }
         
         let hexString: String = String(self[self.index(self.startIndex, offsetBy: 1)...])
-        switch (hexString.count) {
+        switch hexString.count {
         case 4:
-            return "#"
-                + String(hexString[self.index(self.startIndex, offsetBy: 1)...])
-                + String(hexString[..<self.index(self.startIndex, offsetBy: 1)])
+          return "#\(String(hexString[self.index(self.startIndex, offsetBy: 1)...]))\(String(hexString[..<self.index(self.startIndex, offsetBy: 1)]))"
         case 8:
-            return "#"
-                + String(hexString[self.index(self.startIndex, offsetBy: 2)...])
-                + String(hexString[..<self.index(self.startIndex, offsetBy: 2)])
+          return "#\(String(hexString[self.index(self.startIndex, offsetBy: 2)...]))\(String(hexString[..<self.index(self.startIndex, offsetBy: 2)]))"
         default:
-            return nil
+          return nil
         }
     }
 }


### PR DESCRIPTION
It seems that swift compiler prefers interpolation over concatenation. Before this changes it took ~1800ms on my MBP new gen to build each of the two cases. With these changes it takes less than 100ms each.