### PR TITLE
Updates Package name to conform to CFBundleIdentifier

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,13 +4,13 @@
 import PackageDescription
 
 let package = Package(
-    name: "UIColor_Hex_Swift",
+    name: "UIColorHexSwift",
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
-            name: "UIColor_Hex_Swift",
+            name: "UIColorHexSwift",
             type: .dynamic,
-            targets: ["UIColor_Hex_Swift"]),
+            targets: ["UIColorHexSwift"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -20,7 +20,7 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
-            name: "UIColor_Hex_Swift",
+            name: "UIColorHexSwift",
             dependencies: [],
             path: "HEXColor"
         )


### PR DESCRIPTION
When uploading to Testflight, we noticed the following error:
```
This bundle is invalid. 
The bundle at path [...]/UIColor_Hex_Swift.framework has an invalid CFBundleIdentifier 'UIColor_Hex_Swift'.
There are invalid characters(characters that are not dots, hyphen and alphanumerics) that have been replaced with their code point 'UIColor\u005fHex\u005fSwift'.
CFBundleIdentifier must be present, must contain only alphanumerics, dots, hyphens and must not end with a dot. 
```

This PR renames the package to make it conform to the CFBundleIdentifier spec.

See [Core Foundation Keys](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/TP40009249-102070-TPXREF105)