### PR TITLE
Do not specify .dynamic linking

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,6 @@ let package = Package(
         // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "UIColor_Hex_Swift",
-            type: .dynamic,
             targets: ["UIColor_Hex_Swift"]),
     ],
     dependencies: [


### PR DESCRIPTION
Packages should not generally need to specify how they should be linked:
https://forums.swift.org/t/building-distributable-executable-using-swiftpm/13792/9

Dynamic linking seems to cause all kinds of problems in Xcode in particular when using SwiftUI previews inside
packages. Removing this fixes the problem.