### PR TITLE
Swift UI support

### DIFF
--- a/HEXColor.xcodeproj/project.pbxproj
+++ b/HEXColor.xcodeproj/project.pbxproj
@@ -22,6 +22,9 @@
 		AA06B5111BC225210049FE14 /* HEXColor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA06B5061BC225210049FE14 /* HEXColor.framework */; };
 		AA06B5161BC225210049FE14 /* HEXColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA06B5151BC225210049FE14 /* HEXColorTests.swift */; };
 		AA06B5231BC233F80049FE14 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA06B5221BC233F80049FE14 /* UIColorExtension.swift */; };
+		C62294E42771E8BB00E20AA1 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62294E32771E8BB00E20AA1 /* ColorExtension.swift */; };
+		C62294E52771E8BB00E20AA1 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62294E32771E8BB00E20AA1 /* ColorExtension.swift */; };
+		C62294E62771E8BB00E20AA1 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62294E32771E8BB00E20AA1 /* ColorExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,6 +53,7 @@
 		AA06B5151BC225210049FE14 /* HEXColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HEXColorTests.swift; sourceTree = "<group>"; };
 		AA06B5171BC225210049FE14 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AA06B5221BC233F80049FE14 /* UIColorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
+		C62294E32771E8BB00E20AA1 /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,6 +128,7 @@
 				6534822D202463B00032A09E /* UIColorInputError.swift */,
 				6534822F202464370032A09E /* StringExtension.swift */,
 				43BCBCBE1C51BA9900205107 /* Supporting Files */,
+				C62294E32771E8BB00E20AA1 /* ColorExtension.swift */,
 			);
 			path = HEXColor;
 			sourceTree = "<group>";
@@ -329,6 +334,7 @@
 				43BCBCC21C51BB0100205107 /* UIColorExtension.swift in Sources */,
 				7045417C2025CBFD00A1D3D8 /* UIColorInputError.swift in Sources */,
 				7045417E2025CC0000A1D3D8 /* StringExtension.swift in Sources */,
+				C62294E52771E8BB00E20AA1 /* ColorExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -339,6 +345,7 @@
 				A160F2272259970700E8D3C3 /* UIColorExtension.swift in Sources */,
 				A160F2282259970700E8D3C3 /* UIColorInputError.swift in Sources */,
 				A160F2292259970700E8D3C3 /* StringExtension.swift in Sources */,
+				C62294E62771E8BB00E20AA1 /* ColorExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -349,6 +356,7 @@
 				AA06B5231BC233F80049FE14 /* UIColorExtension.swift in Sources */,
 				6534822E202463B00032A09E /* UIColorInputError.swift in Sources */,
 				65348230202464370032A09E /* StringExtension.swift in Sources */,
+				C62294E42771E8BB00E20AA1 /* ColorExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/HEXColor.xcodeproj/project.pbxproj
+++ b/HEXColor.xcodeproj/project.pbxproj
@@ -8,23 +8,23 @@
 
 /* Begin PBXBuildFile section */
 		43BCBCC11C51BAFE00205107 /* HEXColor.h in Headers */ = {isa = PBXBuildFile; fileRef = AA06B5091BC225210049FE14 /* HEXColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		43BCBCC21C51BB0100205107 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA06B5221BC233F80049FE14 /* UIColorExtension.swift */; };
 		56FC6F9E200DF8A400F87A72 /* OCHexColorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 56FC6F9D200DF8A400F87A72 /* OCHexColorTests.m */; };
-		6534822E202463B00032A09E /* UIColorInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6534822D202463B00032A09E /* UIColorInputError.swift */; };
 		65348230202464370032A09E /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6534822F202464370032A09E /* StringExtension.swift */; };
-		7045417C2025CBFD00A1D3D8 /* UIColorInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6534822D202463B00032A09E /* UIColorInputError.swift */; };
 		7045417E2025CC0000A1D3D8 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6534822F202464370032A09E /* StringExtension.swift */; };
 		A160F226225996EB00E8D3C3 /* HEXColor.h in Headers */ = {isa = PBXBuildFile; fileRef = AA06B5091BC225210049FE14 /* HEXColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A160F2272259970700E8D3C3 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA06B5221BC233F80049FE14 /* UIColorExtension.swift */; };
-		A160F2282259970700E8D3C3 /* UIColorInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6534822D202463B00032A09E /* UIColorInputError.swift */; };
 		A160F2292259970700E8D3C3 /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6534822F202464370032A09E /* StringExtension.swift */; };
 		AA06B50A1BC225210049FE14 /* HEXColor.h in Headers */ = {isa = PBXBuildFile; fileRef = AA06B5091BC225210049FE14 /* HEXColor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AA06B5111BC225210049FE14 /* HEXColor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA06B5061BC225210049FE14 /* HEXColor.framework */; };
 		AA06B5161BC225210049FE14 /* HEXColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA06B5151BC225210049FE14 /* HEXColorTests.swift */; };
-		AA06B5231BC233F80049FE14 /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA06B5221BC233F80049FE14 /* UIColorExtension.swift */; };
 		C62294E42771E8BB00E20AA1 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62294E32771E8BB00E20AA1 /* ColorExtension.swift */; };
 		C62294E52771E8BB00E20AA1 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62294E32771E8BB00E20AA1 /* ColorExtension.swift */; };
 		C62294E62771E8BB00E20AA1 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C62294E32771E8BB00E20AA1 /* ColorExtension.swift */; };
+		E74FA847278AF9280039613E /* PlatformColorInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74FA845278AF9280039613E /* PlatformColorInputError.swift */; };
+		E74FA848278AF9280039613E /* PlatformColorInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74FA845278AF9280039613E /* PlatformColorInputError.swift */; };
+		E74FA849278AF9280039613E /* PlatformColorInputError.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74FA845278AF9280039613E /* PlatformColorInputError.swift */; };
+		E74FA84A278AF9280039613E /* PlatformColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74FA846278AF9280039613E /* PlatformColorExtension.swift */; };
+		E74FA84B278AF9280039613E /* PlatformColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74FA846278AF9280039613E /* PlatformColorExtension.swift */; };
+		E74FA84C278AF9280039613E /* PlatformColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E74FA846278AF9280039613E /* PlatformColorExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,7 +43,6 @@
 		43BCBCBF1C51BAA800205107 /* iOS-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "iOS-Info.plist"; sourceTree = "<group>"; };
 		56FC6F9C200DF8A400F87A72 /* HEXColorTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "HEXColorTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		56FC6F9D200DF8A400F87A72 /* OCHexColorTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OCHexColorTests.m; sourceTree = "<group>"; };
-		6534822D202463B00032A09E /* UIColorInputError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorInputError.swift; sourceTree = "<group>"; };
 		6534822F202464370032A09E /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
 		A160F21E2259950200E8D3C3 /* HEXColor_macOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = HEXColor_macOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A160F2212259950200E8D3C3 /* macOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "macOS-Info.plist"; sourceTree = "<group>"; };
@@ -52,8 +51,9 @@
 		AA06B5101BC225210049FE14 /* HEXColorTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HEXColorTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AA06B5151BC225210049FE14 /* HEXColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HEXColorTests.swift; sourceTree = "<group>"; };
 		AA06B5171BC225210049FE14 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		AA06B5221BC233F80049FE14 /* UIColorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		C62294E32771E8BB00E20AA1 /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
+		E74FA845278AF9280039613E /* PlatformColorInputError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlatformColorInputError.swift; sourceTree = "<group>"; };
+		E74FA846278AF9280039613E /* PlatformColorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlatformColorExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,9 +123,9 @@
 		AA06B5081BC225210049FE14 /* HEXColor */ = {
 			isa = PBXGroup;
 			children = (
+				E74FA846278AF9280039613E /* PlatformColorExtension.swift */,
+				E74FA845278AF9280039613E /* PlatformColorInputError.swift */,
 				AA06B5091BC225210049FE14 /* HEXColor.h */,
-				AA06B5221BC233F80049FE14 /* UIColorExtension.swift */,
-				6534822D202463B00032A09E /* UIColorInputError.swift */,
 				6534822F202464370032A09E /* StringExtension.swift */,
 				43BCBCBE1C51BA9900205107 /* Supporting Files */,
 				C62294E32771E8BB00E20AA1 /* ColorExtension.swift */,
@@ -331,8 +331,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				43BCBCC21C51BB0100205107 /* UIColorExtension.swift in Sources */,
-				7045417C2025CBFD00A1D3D8 /* UIColorInputError.swift in Sources */,
+				E74FA84B278AF9280039613E /* PlatformColorExtension.swift in Sources */,
+				E74FA848278AF9280039613E /* PlatformColorInputError.swift in Sources */,
 				7045417E2025CC0000A1D3D8 /* StringExtension.swift in Sources */,
 				C62294E52771E8BB00E20AA1 /* ColorExtension.swift in Sources */,
 			);
@@ -342,8 +342,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A160F2272259970700E8D3C3 /* UIColorExtension.swift in Sources */,
-				A160F2282259970700E8D3C3 /* UIColorInputError.swift in Sources */,
+				E74FA84C278AF9280039613E /* PlatformColorExtension.swift in Sources */,
+				E74FA849278AF9280039613E /* PlatformColorInputError.swift in Sources */,
 				A160F2292259970700E8D3C3 /* StringExtension.swift in Sources */,
 				C62294E62771E8BB00E20AA1 /* ColorExtension.swift in Sources */,
 			);
@@ -353,8 +353,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AA06B5231BC233F80049FE14 /* UIColorExtension.swift in Sources */,
-				6534822E202463B00032A09E /* UIColorInputError.swift in Sources */,
+				E74FA84A278AF9280039613E /* PlatformColorExtension.swift in Sources */,
+				E74FA847278AF9280039613E /* PlatformColorInputError.swift in Sources */,
 				65348230202464370032A09E /* StringExtension.swift in Sources */,
 				C62294E42771E8BB00E20AA1 /* ColorExtension.swift in Sources */,
 			);
@@ -653,6 +653,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				INFOPLIST_FILE = HEXColorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pdq.HEXColorTests;
@@ -667,6 +668,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				INFOPLIST_FILE = HEXColorTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pdq.HEXColorTests;

--- a/HEXColor/ColorExtension.swift
+++ b/HEXColor/ColorExtension.swift
@@ -1,8 +1,6 @@
 import SwiftUI
 
-@available(watchOSApplicationExtension 6.0, *)
-@available(macOS 10.15, *)
-@available(iOSApplicationExtension 13.0, *)
+@available(watchOSApplicationExtension 6.0, macOS 10.15, iOSApplicationExtension 13.0, *)
 extension Color {
     public init(hex3: UInt16, alpha: CGFloat = 1) {
         self.init(PlatformColor(hex3: hex3, alpha: alpha))
@@ -21,7 +19,7 @@ extension Color {
     }
 
 #if os(macOS)
-    public init?(_ rgba: String, defaultColor: NSColor = NSColor.clear) {
+    public init?(rgba: String, defaultColor: NSColor = NSColor.clear) {
         if let platformColor = PlatformColor(rgba, defaultColor: defaultColor) {
             self.init(platformColor)
         } else {
@@ -29,7 +27,7 @@ extension Color {
         }
     }
 #else
-    public init(_ rgba: String, defaultColor: UIColor = UIColor.clear) {
+    public init(rgba: String, defaultColor: UIColor = UIColor.clear) {
         self.init(PlatformColor(rgba, defaultColor: defaultColor))
     }
 #endif

--- a/HEXColor/ColorExtension.swift
+++ b/HEXColor/ColorExtension.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-@available(watchOSApplicationExtension 6.0, macOS 10.15, iOSApplicationExtension 13.0, *)
+@available(watchOS 6.0, macOS 10.15, iOS 13.0, *)
 extension Color {
     public init(hex3: UInt16, alpha: CGFloat = 1) {
         self.init(PlatformColor(hex3: hex3, alpha: alpha))

--- a/HEXColor/ColorExtension.swift
+++ b/HEXColor/ColorExtension.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+@available(watchOSApplicationExtension 6.0, *)
+@available(macOS 10.15, *)
+@available(iOSApplicationExtension 13.0, *)
+extension Color {
+    public init(hex3: UInt16, alpha: CGFloat = 1) {
+        self.init(PlatformColor(hex3: hex3, alpha: alpha))
+    }
+
+    public init(hex4: UInt16) {
+        self.init(PlatformColor(hex4: hex4))
+    }
+
+    public init(hex6: UInt32, alpha: CGFloat = 1) {
+        self.init(PlatformColor(hex6: hex6, alpha: alpha))
+    }
+
+    public init(hex8: UInt32) {
+        self.init(PlatformColor(hex8: hex8))
+    }
+
+#if os(macOS)
+    public init?(_ rgba: String, defaultColor: NSColor = NSColor.clear) {
+        if let platformColor = PlatformColor(rgba, defaultColor: defaultColor) {
+            self.init(platformColor)
+        } else {
+            return nil
+        }
+    }
+#else
+    public init(_ rgba: String, defaultColor: UIColor = UIColor.clear) {
+        self.init(PlatformColor(rgba, defaultColor: defaultColor))
+    }
+#endif
+}

--- a/HEXColor/PlatformColorExtension.swift
+++ b/HEXColor/PlatformColorExtension.swift
@@ -1,5 +1,5 @@
 //
-//  UIColorExtension.swift
+//  PlatformColorExtension.swift
 //  HEXColor
 //
 //  Created by R0CKSTAR on 6/13/14.
@@ -80,7 +80,7 @@ typealias PlatformColor = UIColor
      */
     public convenience init(rgba_throws rgba: String) throws {
         guard rgba.hasPrefix("#") else {
-            let error = UIColorInputError.missingHashMarkAsPrefix(rgba)
+            let error = PlatformColorInputError.missingHashMarkAsPrefix(rgba)
             print(error.localizedDescription)
             throw error
         }
@@ -89,7 +89,7 @@ typealias PlatformColor = UIColor
         var hexValue:  UInt32 = 0
         
         guard Scanner(string: hexString).scanHexInt32(&hexValue) else {
-            let error = UIColorInputError.unableToScanHexValue(rgba)
+            let error = PlatformColorInputError.unableToScanHexValue(rgba)
             print(error.localizedDescription)
             throw error
         }
@@ -104,7 +104,7 @@ typealias PlatformColor = UIColor
         case 8:
             self.init(hex8: hexValue)
         default:
-            let error = UIColorInputError.mismatchedHexStringLength(rgba)
+            let error = PlatformColorInputError.mismatchedHexStringLength(rgba)
             print(error.localizedDescription)
             throw error
         }
@@ -134,7 +134,7 @@ typealias PlatformColor = UIColor
 #endif
     
     /**
-     Hex string of a UIColor instance, throws error.
+     Hex string of a PlatformColor instance, throws error.
      
      - parameter includeAlpha: Whether the alpha should be included.
      */
@@ -146,7 +146,7 @@ typealias PlatformColor = UIColor
         self.getRed(&r, green: &g, blue: &b, alpha: &a)
         
         guard r >= 0 && r <= 1 && g >= 0 && g <= 1 && b >= 0 && b <= 1 else {
-            let error = UIColorInputError.unableToOutputHexStringForWideDisplayColor
+            let error = PlatformColorInputError.unableToOutputHexStringForWideDisplayColor
             print(error.localizedDescription)
             throw error
         }
@@ -162,7 +162,7 @@ typealias PlatformColor = UIColor
     }
     
     /**
-     Hex string of a UIColor instance, fails to empty string.
+     Hex string of a PlatformColor instance, fails to empty string.
      
      - parameter includeAlpha: Whether the alpha should be included.
      */

--- a/HEXColor/PlatformColorInputError.swift
+++ b/HEXColor/PlatformColorInputError.swift
@@ -1,5 +1,5 @@
 //
-//  UIColorInputError.swift
+//  PlatformColorInputError.swift
 //  HEXColor-iOS
 //
 //  Created by Sergey Pugach on 2/2/18.
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum UIColorInputError: Error {
+public enum PlatformColorInputError: Error {
     
     case missingHashMarkAsPrefix(String)
     case unableToScanHexValue(String)
@@ -16,7 +16,7 @@ public enum UIColorInputError: Error {
     case unableToOutputHexStringForWideDisplayColor
 }
 
-extension UIColorInputError: LocalizedError {
+extension PlatformColorInputError: LocalizedError {
     
     public var errorDescription: String? {
         switch self {

--- a/HEXColor/UIColorExtension.swift
+++ b/HEXColor/UIColorExtension.swift
@@ -8,14 +8,14 @@
 
 #if os(macOS)
 import Cocoa
-typealias Color = NSColor
+typealias PlatformColor = NSColor
 #else
 import UIKit
-typealias Color = UIColor
+typealias PlatformColor = UIColor
 #endif
 
 
-@objc extension Color {
+@objc extension PlatformColor {
     /**
      The shorthand three-digit hexadecimal representation of color.
      #RGB defines to the color #RRGGBB.
@@ -117,7 +117,7 @@ typealias Color = UIColor
      */
 #if os(macOS)
     public convenience init?(_ rgba: String, defaultColor: NSColor = NSColor.clear) {
-        guard let color = try? Color(rgba_throws: rgba) else {
+        guard let color = try? PlatformColor(rgba_throws: rgba) else {
             self.init(cgColor: defaultColor.cgColor)
             return
         }
@@ -125,7 +125,7 @@ typealias Color = UIColor
     }
 #else
     public convenience init(_ rgba: String, defaultColor: UIColor = UIColor.clear) {
-        guard let color = try? UIColor(rgba_throws: rgba) else {
+        guard let color = try? PlatformColor(rgba_throws: rgba) else {
             self.init(cgColor: defaultColor.cgColor)
             return
         }

--- a/HEXColorTests/HEXColorTests.swift
+++ b/HEXColorTests/HEXColorTests.swift
@@ -231,11 +231,11 @@ class HEXColorTests: XCTestCase {
     func testStringInputErrorMissingHashMarkAsPrefix() {
         do {
             let _ = try UIColor(rgba_throws: "FFFFFFFF")
-        } catch UIColorInputError.missingHashMarkAsPrefix {
+        } catch PlatformColorInputError.missingHashMarkAsPrefix {
             XCTAssertTrue(true)
-        } catch UIColorInputError.unableToScanHexValue {
+        } catch PlatformColorInputError.unableToScanHexValue {
             XCTAssertTrue(false)
-        } catch UIColorInputError.mismatchedHexStringLength {
+        } catch PlatformColorInputError.mismatchedHexStringLength {
             XCTAssertTrue(false)
         } catch {
             XCTAssertTrue(false)
@@ -245,11 +245,11 @@ class HEXColorTests: XCTestCase {
     func testStringInputErrorMismatchedHexStringLength() {
         do {
             let _ = try UIColor(rgba_throws: "#FFFFFFF")
-        } catch UIColorInputError.missingHashMarkAsPrefix {
+        } catch PlatformColorInputError.missingHashMarkAsPrefix {
             XCTAssertTrue(false)
-        } catch UIColorInputError.unableToScanHexValue {
+        } catch PlatformColorInputError.unableToScanHexValue {
             XCTAssertTrue(false)
-        } catch UIColorInputError.mismatchedHexStringLength {
+        } catch PlatformColorInputError.mismatchedHexStringLength {
             XCTAssertTrue(true)
         } catch {
             XCTAssertTrue(false)
@@ -259,11 +259,11 @@ class HEXColorTests: XCTestCase {
     func testStringInputErrorUnableToScanHexValue() {
         do {
             let _ = try UIColor(rgba_throws: "#ONMPQRST")
-        } catch UIColorInputError.missingHashMarkAsPrefix {
+        } catch PlatformColorInputError.missingHashMarkAsPrefix {
             XCTAssertTrue(false)
-        } catch UIColorInputError.unableToScanHexValue {
+        } catch PlatformColorInputError.unableToScanHexValue {
             XCTAssertTrue(true)
-        } catch UIColorInputError.mismatchedHexStringLength {
+        } catch PlatformColorInputError.mismatchedHexStringLength {
             XCTAssertTrue(false)
         } catch {
             XCTAssertTrue(false)
@@ -332,14 +332,14 @@ class HEXColorTests: XCTestCase {
             XCTAssertEqual("", color.hexString(true))
             do {
                 let _ = try color.hexStringThrows(true)
-            } catch UIColorInputError.unableToOutputHexStringForWideDisplayColor {
+            } catch PlatformColorInputError.unableToOutputHexStringForWideDisplayColor {
                 XCTAssertTrue(true)
             } catch {
                 XCTAssertTrue(false)
             }
             do {
                 let _ = try color.hexStringThrows(false)
-            } catch UIColorInputError.unableToOutputHexStringForWideDisplayColor {
+            } catch PlatformColorInputError.unableToOutputHexStringForWideDisplayColor {
                 XCTAssertTrue(true)
             } catch {
                 XCTAssertTrue(false)


### PR DESCRIPTION
This pull request adds SwiftUI support for the Color type introduced in SwiftUI.
Most initializers are the same, however, rgba parameter is now named, because SwiftUI's Color has a constructor with unnamed string as a parameter.