### PR TITLE
Update ColorExtension.swift

### DIFF
--- a/HEXColor/ColorExtension.swift
+++ b/HEXColor/ColorExtension.swift
@@ -1,3 +1,5 @@
+#if arch(arm64) || arch(x86_64)
+
 import SwiftUI
 
 @available(watchOS 6.0, macOS 10.15, iOS 13.0, *)
@@ -32,3 +34,5 @@ extension Color {
     }
 #endif
 }
+
+#endif


### PR DESCRIPTION
Building for canvas yields "Color not found." because sometimes it will try to build as armv7. This prevents the SwiftUI section from building with armv7.

NOTE: This could probably also be implemented with a `canImport` macro. It's all the same use case to me, so up to you.