### PR TITLE
fix: inconsistent API between iOS and macOS.

### DIFF
--- a/HEXColor/ColorExtension.swift
+++ b/HEXColor/ColorExtension.swift
@@ -21,11 +21,11 @@ extension Color {
     }
 
 #if os(macOS)
-    public init?(rgba: String, defaultColor: NSColor = NSColor.clear) {
+    public init(rgba: String, defaultColor: NSColor = NSColor.clear) {
         if let platformColor = PlatformColor(rgba, defaultColor: defaultColor) {
             self.init(platformColor)
         } else {
-            return nil
+            self.init(defaultColor)
         }
     }
 #else


### PR DESCRIPTION
When using SwiftUI, the API to create Color using `public init(rgba: String, defaultColor: UIColor = UIColor.clear)` is not consistent between iOS and macOS. This could cause compile errors in a multi-platform project.